### PR TITLE
GIG24/reservation

### DIFF
--- a/db/migration/20250609141249_reservations.sql
+++ b/db/migration/20250609141249_reservations.sql
@@ -1,6 +1,8 @@
 -- +goose Up
 CREATE TABLE IF NOT EXISTS reservations (
     id UUID PRIMARY KEY DEFAULT uuid_generate_v4(),
+    availability_id UUID NOT NULL REFERENCES availabilities(id) ON DELETE CASCADE,
+
 
     reservation_reference TEXT NOT NULL UNIQUE, -- ID intern 
     external_reservation_reference TEXT NOT NULL,

--- a/db/queries/reservations.sql
+++ b/db/queries/reservations.sql
@@ -1,0 +1,34 @@
+-- name: ReserveOrUpdateReservation :one
+INSERT INTO reservations (
+    reservation_reference, external_reservation_reference, reseller_id, availability_id, date_time, quantity, status
+)
+VALUES (
+    $1, $2, $3, $4, $5, $6, 'CONFIRMED'
+)
+ON CONFLICT (reseller_id, external_reservation_reference) DO UPDATE 
+SET 
+    reservation_reference = EXCLUDED.reservation_reference,
+    availability_id = EXCLUDED.availability_id,
+    date_time = EXCLUDED.date_time,
+    quantity = EXCLUDED.quantity,
+    status = 'CONFIRMED',
+    updated_at = now()
+RETURNING id, reservation_reference, external_reservation_reference, reseller_id, availability_id, date_time, quantity, status, created_at, updated_at;
+
+-- name: GetReservationByExternalReference :one
+SELECT id, reservation_reference, external_reservation_reference, reseller_id, availability_id, date_time, quantity, status, created_at, updated_at
+FROM reservations
+WHERE reseller_id = $1 AND external_reservation_reference = $2;
+
+-- name: GetReservationByReference :one
+SELECT id, reservation_reference, external_reservation_reference, reseller_id, availability_id, date_time, quantity, status, created_at, updated_at
+FROM reservations
+WHERE reservation_reference = $1;
+
+-- name: CancelReservation :one
+UPDATE reservations
+SET status = 'CANCELED', updated_at = now()
+WHERE reservation_reference = $1
+RETURNING id, reservation_reference, external_reservation_reference, reseller_id, availability_id, date_time, quantity, status, created_at, updated_at;
+
+

--- a/dto/ReservationDTO.go
+++ b/dto/ReservationDTO.go
@@ -1,0 +1,13 @@
+package dto
+
+import "time"
+
+type ReservationDTO struct {
+	ReservationReference         string    `json:"reservationReference"`
+	ExternalReservationReference string    `json:"externalReservationReference"`
+	ResellerID                   string    `json:"resellerId"`
+	AvailabilityID               string    `json:"availabilityId"`
+	DateTime                     time.Time `json:"dateTime"`
+	Quantity                     int32     `json:"quantity"`
+	Status                       string    `json:"status"`
+}

--- a/dto/ReservationtoDto.go
+++ b/dto/ReservationtoDto.go
@@ -1,0 +1,39 @@
+package dto
+
+import (
+	"example.com/model"
+	"github.com/google/uuid"
+)
+
+func ReservationToDTO(res *model.Reservation) *ReservationDTO {
+	return &ReservationDTO{
+		ReservationReference:         res.ReservationReference,
+		ExternalReservationReference: res.ExternalReservationReference,
+		ResellerID:                   res.ResellerID.String(),
+		AvailabilityID:               res.AvailabilityID.String(),
+		DateTime:                     res.DateTime,
+		Quantity:                     res.Quantity,
+		Status:                       res.Status,
+	}
+}
+
+func (dto ReservationDTO) ToModel() (model.Reservation, error) {
+	availabilityID, err := uuid.Parse(dto.AvailabilityID)
+	if err != nil {
+		return model.Reservation{}, err
+	}
+	resellerID, err := uuid.Parse(dto.ResellerID)
+	if err != nil {
+		return model.Reservation{}, err
+	}
+
+	return model.Reservation{
+		ReservationReference:         dto.ReservationReference,
+		ExternalReservationReference: dto.ExternalReservationReference,
+		ResellerID:                   resellerID,
+		AvailabilityID:               availabilityID,
+		DateTime:                     dto.DateTime,
+		Quantity:                     dto.Quantity,
+		Status:                       dto.Status,
+	}, nil
+}

--- a/handler/ResellerHandler.go
+++ b/handler/ResellerHandler.go
@@ -13,29 +13,29 @@ import (
 type ResellerHandler struct {
 	service service.ResellerService
 	availabilityHandler *AvailabilityHandler
+	reservationHandler *ReservationHandler
 
 }
 
-func NewResellerHandler(service service.ResellerService, availabilityHandler *AvailabilityHandler) *ResellerHandler {
+func NewResellerHandler(service service.ResellerService, availabilityHandler *AvailabilityHandler, 
+				reservationHandler *ReservationHandler) *ResellerHandler {
 	return &ResellerHandler{
 		service: service,
 		availabilityHandler: availabilityHandler,
+		reservationHandler: reservationHandler,
 	}
 }
 
 
 func (h *ResellerHandler) Routes(r chi.Router) {
-	// r.Route("/api/resellers", func(r chi.Router) {
-		// r.Post("/register", h.Register)
-		// r.Post("/login", h.Login)
-		// r.Get("/", h.ListAll)
-		// r.Get("/{id}", h.GetByID)
-		// r.Delete("/{id}", h.Delete)
-		r.With(BasicAuth(h.service)).Get("/1/availabilities/", h.availabilityHandler.getAvailabilitiesInRange)
-
-
-	// })
+	r.Route("/1", func(r chi.Router) {
+		r.With(BasicAuth(h.service)).Get("/availabilities/", h.availabilityHandler.getAvailabilitiesInRange)
+		r.With(BasicAuth(h.service)).Post("/reserve", h.reservationHandler.Reserve)
+		r.With(BasicAuth(h.service)).Post("/cancel-reservation", h.reservationHandler.Cancel)
+		r.With(BasicAuth(h.service)).Get("/reservation/{reservationReference}", h.reservationHandler.ViewReservation)
+	})
 }
+
 
 // Register reseller
 func (h *ResellerHandler) Register(w http.ResponseWriter, r *http.Request) {

--- a/handler/reservationHandler.go
+++ b/handler/reservationHandler.go
@@ -1,0 +1,199 @@
+package handler
+
+import (
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"time"
+
+	"example.com/dto"
+	"example.com/service"
+	"github.com/go-chi/chi/v5"
+)
+
+//request structure
+type ReserveRequest struct {
+	Data struct {
+		DateTime                  string `json:"dateTime"`
+		Quantity                  int    `json:"quantity"`
+		ExternalReservationReference string `json:"externalReservationReference"`
+	} `json:"data"`
+}
+
+type CancelRequest struct {
+	Data struct {
+		ReservationReference         string `json:"reservationReference"`
+		ExternalReservationReference string `json:"externalReservationReference"`
+	} `json:"data"`
+}
+
+type ViewResponse struct {
+	Data struct {
+		ReservationReference         string `json:"reservationReference"`
+		ExternalReservationReference string `json:"externalReservationReference"`
+		DateTime                     string `json:"dateTime"`
+		Quantity                     int32  `json:"quantity"`
+		Status                       string `json:"status"`
+	} `json:"data"`
+}
+
+type ReserveResponse struct {
+	Data struct {
+		ReservationReference string `json:"reservationReference"`
+	} `json:"data"`
+}
+
+type ErrorResponse struct {
+	ErrorCode    string `json:"errorCode"`
+	ErrorMessage string `json:"errorMessage"`
+}
+
+
+type ReservationHandler struct {
+	ReservationService service.ReservationService
+	AvailabilityService service.AvailabilityService
+}
+
+
+func NewReservationHandler(reservationService service.ReservationService, availabilityService service.AvailabilityService) *ReservationHandler {
+	return &ReservationHandler{
+		ReservationService: reservationService,
+		AvailabilityService: availabilityService,
+	}
+}
+
+
+
+
+
+func (h *ReservationHandler) Reserve(w http.ResponseWriter, r *http.Request) {
+	var req ReserveRequest
+	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+		h.writeError(w, "VALIDATION_FAILURE", "Invalid JSON")
+		return
+	}
+	//fmt.Println("Reserve request:", req)
+
+
+
+	reseller, ok := r.Context().Value(ResellerContextKey).(*dto.ResellerResponse)
+	if !ok {
+		h.writeError(w, "AUTHORIZATION_FAILURE", "Unauthorized")
+		return
+	}
+
+	dateTime, err := time.Parse(time.RFC3339, req.Data.DateTime)
+	if err != nil {
+		h.writeError(w, "VALIDATION_FAILURE", "Invalid dateTime format")
+		return
+	}
+
+	id, err := h.AvailabilityService.GetAvailabilityIDForReservation(r.Context(), dateTime)
+	if err != nil {
+		h.writeError(w, "VALIDATION_FAILURE", "Invalid availability")
+		fmt.Println(err)
+		return
+	}
+		//fmt.Println("Availability ID for reservation:", id)
+	reservation := dto.ReservationDTO{
+		ResellerID:                   reseller.Id,
+		AvailabilityID:               id.String(),
+		DateTime:                     dateTime,
+		Quantity:                     int32(req.Data.Quantity),
+		ExternalReservationReference: req.Data.ExternalReservationReference,
+	}
+
+	result, err := h.ReservationService.ReserveOrUpdate(r.Context(), reservation)
+	if err != nil {
+		if err.Error() == "NO_AVAILABILITY" {
+			h.writeError(w, "NO_AVAILABILITY", err.Error())
+			return
+		}
+		h.writeError(w, "INTERNAL_SYSTEM_FAILURE", err.Error())
+		return
+	}
+
+	resp := ReserveResponse{}
+	resp.Data.ReservationReference = result.ReservationReference
+	h.writeJSON(w, resp)
+}
+
+
+
+func (h *ReservationHandler) Cancel(w http.ResponseWriter, r *http.Request) {
+	var req CancelRequest
+	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+		h.writeError(w, "VALIDATION_FAILURE", "Invalid JSON")
+		return
+	}
+
+	_, ok := r.Context().Value(ResellerContextKey).(*dto.ResellerResponse)
+	if !ok {
+		h.writeError(w, "AUTHORIZATION_FAILURE", "Unauthorized")
+		return
+	}
+
+	err := h.ReservationService.CancelReservation(r.Context(), req.Data.ReservationReference, req.Data.ExternalReservationReference)
+	if err != nil {
+		switch err.Error() {
+		case "INVALID_RESERVATION":
+			h.writeError(w, "INVALID_RESERVATION", err.Error())
+		case "RESERVATION_ALREADY_CANCELED":
+			h.writeError(w, "RESERVATION_ALREADY_CANCELED", err.Error())
+		default:
+			h.writeError(w, "INTERNAL_SYSTEM_FAILURE", err.Error())
+		}
+		return
+	}
+
+	// Success 200 OK cu gol data:
+	h.writeJSON(w, map[string]interface{}{"data": map[string]interface{}{}})
+}
+
+
+
+
+
+func (h *ReservationHandler) ViewReservation(w http.ResponseWriter, r *http.Request) {
+	reservationReference := chi.URLParam(r, "reservationReference")
+
+	_, ok := r.Context().Value(ResellerContextKey).(*dto.ResellerResponse)
+	if !ok {
+		h.writeError(w, "AUTHORIZATION_FAILURE", "Unauthorized")
+		return
+	}
+
+	result, err := h.ReservationService.GetByReservationReference(r.Context(), reservationReference)
+	if err != nil {
+		h.writeError(w, "INVALID_RESERVATION", err.Error())
+		return
+	}
+
+	resp := ViewResponse{}
+	resp.Data.ReservationReference = result.ReservationReference
+	resp.Data.ExternalReservationReference = result.ExternalReservationReference
+	resp.Data.DateTime = result.DateTime.Format(time.RFC3339)
+	resp.Data.Quantity = result.Quantity
+	resp.Data.Status = result.Status
+
+	h.writeJSON(w, resp)
+}
+
+
+
+
+
+func (h *ReservationHandler) writeError(w http.ResponseWriter, code string, message string) {
+	w.Header().Set("Content-Type", "application/json")
+	w.WriteHeader(http.StatusOK)
+	json.NewEncoder(w).Encode(ErrorResponse{
+		ErrorCode:    code,
+		ErrorMessage: message,
+	})
+}
+
+func (h *ReservationHandler) writeJSON(w http.ResponseWriter, data interface{}) {
+	w.Header().Set("Content-Type", "application/json")
+	w.WriteHeader(http.StatusOK)
+	json.NewEncoder(w).Encode(data)
+}

--- a/handler/routes.go
+++ b/handler/routes.go
@@ -16,9 +16,7 @@ type RouteDependencies struct {
 func SetupRoutes(dep RouteDependencies) *chi.Mux {
 	r := chi.NewRouter()
 	r.Use(JWTContextMiddleware(dep.JwtHelper))
-	if dep.ResellerHandler != nil {
-		dep.ResellerHandler.Routes(r)
-	}
+	
 
 	// Guest-only (login/register)
 	r.Group(func(r chi.Router) {
@@ -46,5 +44,9 @@ func SetupRoutes(dep RouteDependencies) *chi.Mux {
 		r.Put("/availabilities/{id}", dep.AvailabilityHandler.updateAvailability)
 		r.Delete("/availabilities/{id}", dep.AvailabilityHandler.deleteAvailability)
 	})
+
+	if dep.ResellerHandler != nil {
+		dep.ResellerHandler.Routes(r)
+	}
 	return r
 }

--- a/main.go
+++ b/main.go
@@ -23,7 +23,7 @@ func main() {
 	// fmt.Println(data.UTC().Format(time.DateOnly))
 	// loc:=time.FixedZone("Europe/Bucharest", 2*60*60)
 	// fmt.Println(data.UTC().In(loc).Format(time.DateOnly))
-
+	
 
 	
 
@@ -31,20 +31,26 @@ func main() {
 
 	userRepository := repository.NewDBUserRepository(queries)
 	availabilityRepository := repository.NewDBAvailabilityRepository(pool, queries)
+	reservationRepo:=repository.NewDbReservationRepository(queries, pool)
+
+
 
 	argonHelper := service.StandardArgon2idHash()
 	userService := service.NewUserService(userRepository, argonHelper)
 	availabilityService := service.NewAvailabilityService(availabilityRepository, pool, queries)
+	reservationService:= service.NewReservationService(reservationRepo, availabilityRepository, pool)
 
 	jwtHelper := service.NewJwtUtil()
 	userHandler := handler.NewUserHandler(userService, jwtHelper)
 	availabilityHandler := handler.NewAvailabilityHandler(userService, availabilityService)
 	pageHandler := handler.NewPageHandler()
+	reservationHandler:=handler.NewReservationHandler(reservationService,*availabilityService)
+
 
 
 	resellerRepo:= repository.NewDbResellerRepository(queries)
 	resellerService := service.NewResellerService(resellerRepo)
-	resellerHandler := handler.NewResellerHandler(resellerService, availabilityHandler)
+	resellerHandler := handler.NewResellerHandler(resellerService, availabilityHandler, reservationHandler)
 
 	r := handler.SetupRoutes(handler.RouteDependencies{
 		UserHandler:         userHandler,

--- a/model/reservation.go
+++ b/model/reservation.go
@@ -1,0 +1,23 @@
+package model
+
+import (
+	"time"
+
+	"github.com/google/uuid"
+)
+
+
+
+
+type Reservation struct {
+    ID                        uuid.UUID
+    AvailabilityID            uuid.UUID
+    ReservationReference      string
+    ExternalReservationReference string
+    ResellerID                uuid.UUID
+    DateTime                  time.Time
+    Quantity                  int32
+    Status                    string    //CONFIRMED, CANCELLED
+    CreatedAt                 time.Time
+    UpdatedAt                 time.Time
+}

--- a/repository/ReservationMapper.go
+++ b/repository/ReservationMapper.go
@@ -1,0 +1,93 @@
+package repository
+
+import (
+	"time"
+
+	"example.com/db"
+	"example.com/model"
+	"github.com/jackc/pgx/v5/pgtype"
+)
+
+type ReservationMapper struct{}
+
+
+// Convert from db.ReserveOrUpdateReservationRow (sqlc) to model.Reservation
+func (m *ReservationMapper) DBReserveOrUpdateReservationToModel(row db.ReserveOrUpdateReservationRow) model.Reservation {
+	return model.Reservation{
+		ID:                           row.ID.Bytes,
+		ReservationReference:         row.ReservationReference,
+		ExternalReservationReference: row.ExternalReservationReference,
+		ResellerID:                   row.ResellerID.Bytes,
+		AvailabilityID:               row.AvailabilityID.Bytes,
+		DateTime:                     row.DateTime.Time,
+		Quantity:                     row.Quantity,
+		Status:                       row.Status,
+		CreatedAt:                    row.CreatedAt.Time,
+		UpdatedAt:                    row.UpdatedAt.Time,
+	}
+}
+
+func (m *ReservationMapper) DBCancelReservationToModel(row db.CancelReservationRow) model.Reservation {
+	return model.Reservation{
+		ID:                           row.ID.Bytes,
+		ReservationReference:         row.ReservationReference,
+		ExternalReservationReference: row.ExternalReservationReference,
+		ResellerID:                   row.ResellerID.Bytes,
+		AvailabilityID:               row.AvailabilityID.Bytes,
+		DateTime:                     row.DateTime.Time,
+		Quantity:                     row.Quantity,
+		Status:                       row.Status,
+		CreatedAt:                    row.CreatedAt.Time,
+		UpdatedAt:                    row.UpdatedAt.Time,
+	}
+}
+
+func (m *ReservationMapper) DBGetReservationByReferenceToModel(row db.GetReservationByReferenceRow) model.Reservation {
+	return model.Reservation{
+		ID:                           row.ID.Bytes,
+		ReservationReference:         row.ReservationReference,
+		ExternalReservationReference: row.ExternalReservationReference,
+		ResellerID:                   row.ResellerID.Bytes,
+		AvailabilityID:               row.AvailabilityID.Bytes,
+		DateTime:                     row.DateTime.Time,
+		Quantity:                     row.Quantity,
+		Status:                       row.Status,
+		CreatedAt:                    row.CreatedAt.Time,
+		UpdatedAt:                    row.UpdatedAt.Time,
+	}
+}
+
+func (m *ReservationMapper) DBGetReservationByExternalReferenceToModel(row db.GetReservationByExternalReferenceRow) model.Reservation {
+	return model.Reservation{
+		ID:                           row.ID.Bytes,
+		ReservationReference:         row.ReservationReference,
+		ExternalReservationReference: row.ExternalReservationReference,
+		ResellerID:                   row.ResellerID.Bytes,
+		AvailabilityID:               row.AvailabilityID.Bytes,
+		DateTime:                     row.DateTime.Time,
+		Quantity:                     row.Quantity,
+		Status:                       row.Status,
+		CreatedAt:                    row.CreatedAt.Time,
+		UpdatedAt:                    row.UpdatedAt.Time,
+	}
+}
+
+
+func (m *ReservationMapper) ModelToReserveOrUpdateParams(res model.Reservation) db.ReserveOrUpdateReservationParams {
+	return db.ReserveOrUpdateReservationParams{
+		ReservationReference:         res.ReservationReference,
+		ExternalReservationReference: res.ExternalReservationReference,
+		ResellerID:                   uuidToPgtype(res.ResellerID),
+		AvailabilityID:               uuidToPgtype(res.AvailabilityID),
+		DateTime:                     timestamptzToPgtype(res.DateTime),
+		Quantity:                     res.Quantity,
+	}
+}
+
+
+
+func timestamptzToPgtype(t time.Time) (out pgtype.Timestamptz) {
+	out.Valid = true
+	out.Time = t
+	return
+}

--- a/repository/ReservationRepository.go
+++ b/repository/ReservationRepository.go
@@ -1,0 +1,29 @@
+package repository
+
+import (
+	"context"
+
+	"example.com/db"
+	"example.com/model"
+	"github.com/jackc/pgx/v5/pgxpool"
+)
+
+
+type ReservationRepository interface {
+	ReserveOrUpdate(ctx context.Context, reservation model.Reservation)(*model.Reservation, error)
+	GetByReservationReference(ctx context.Context, reservationReference string) (*model.Reservation, error)
+	GetByExternalReservationReference(ctx context.Context, reseller_id string,externalreservationReference string) (*model.Reservation, error)
+	CancelReservation(ctx context.Context, reservationReference string)(error)
+}
+
+
+
+
+func NewDbReservationRepository(queries *db.Queries, connPool *pgxpool.Pool) ReservationRepository {
+	return &DBReservationRepository{
+		queries:  queries,
+		mapper:   &ReservationMapper{},
+		connPool: connPool,
+	}
+}
+

--- a/repository/availabilitymapperdb.go
+++ b/repository/availabilitymapperdb.go
@@ -37,6 +37,9 @@ func pgTypeToTime(date pgtype.Date) time.Time {
 	return date.Time
 }
 
+
+
+
 func timeOfDayToPgTimestampTz(td model.TimeOfDay) pgtype.Timestamptz {
 	timestamp := time.Date(1970, 1, 1, int(td.Hour), int(td.Minute), 0, 0, time.Local)
 	return pgtype.Timestamptz{

--- a/repository/availabilityrepo.go
+++ b/repository/availabilityrepo.go
@@ -2,6 +2,7 @@ package repository
 
 import (
 	"context"
+	"time"
 
 	"example.com/db"
 	"example.com/model"
@@ -24,6 +25,8 @@ type AvailabilityRepository interface {
 
 	
 	GetAvailabilitiesInRange(ctx context.Context, 	from, to string) ([]model.OpeningAvailability, error)
+	GetAvailableVacancies(ctx context.Context, availabilityID uuid.UUID) (int32, error)
+	GetAvailabilityIdForReservation(ctx context.Context, queries *db.Queries, date, hour time.Time) (uuid.UUID, error)
 
 	
 }

--- a/repository/dbReservationRepo.go
+++ b/repository/dbReservationRepo.go
@@ -1,0 +1,68 @@
+package repository
+
+import (
+	"context"
+
+	"example.com/db"
+	"example.com/model"
+	"github.com/google/uuid"
+	"github.com/jackc/pgx/v5/pgtype"
+	"github.com/jackc/pgx/v5/pgxpool"
+)
+
+type DBReservationRepository struct {
+	queries  *db.Queries
+	mapper   *ReservationMapper
+	connPool *pgxpool.Pool
+}
+
+
+
+// GetByExternalReservationReference implements ReservationRepository.
+func (d *DBReservationRepository) GetByExternalReservationReference(ctx context.Context, reseller_id string, externalreservationReference string) (*model.Reservation, error) {
+	uuidReseller, err := uuid.Parse(reseller_id)
+	if err != nil {
+		return nil, err
+	}
+
+	params := db.GetReservationByExternalReferenceParams{
+		ResellerID: pgtype.UUID{Bytes: uuidReseller, Valid: true},
+		ExternalReservationReference: externalreservationReference,
+	}
+
+	row, err := d.queries.GetReservationByExternalReference(ctx, params)
+	if err != nil {
+		return nil, err
+	}
+
+	result := d.mapper.DBGetReservationByExternalReferenceToModel(row)
+	return &result, nil
+}
+
+// GetByReservationReference implements ReservationRepository.
+func (d *DBReservationRepository) GetByReservationReference(ctx context.Context, reservationReference string) (*model.Reservation, error) {
+	row, err := d.queries.GetReservationByReference(ctx, reservationReference)
+	if err != nil {
+		return nil, err
+	}
+	result := d.mapper.DBGetReservationByReferenceToModel(row)
+	return &result, nil
+}
+
+// ReserveOrUpdate implements ReservationRepository.
+func (d *DBReservationRepository) ReserveOrUpdate(ctx context.Context, reservation model.Reservation) (*model.Reservation, error) {
+	params := d.mapper.ModelToReserveOrUpdateParams(reservation)
+
+	row, err := d.queries.ReserveOrUpdateReservation(ctx, params)
+	if err != nil {
+		return nil, err
+	}
+
+	result := d.mapper.DBReserveOrUpdateReservationToModel(row)
+	return &result, nil
+}
+// CancelReservation implements ReservationRepository.
+func (d *DBReservationRepository) CancelReservation(ctx context.Context, reservationReference string) error {
+	_, err := d.queries.CancelReservation(ctx, reservationReference)
+	return err	
+}

--- a/service/ResellerServiceImpl.go
+++ b/service/ResellerServiceImpl.go
@@ -13,6 +13,7 @@ import (
 
 type resellerServiceImpl struct {
 	repo repository.ResellerRepository
+	
 }
 
 // Delete implements ResellerService.

--- a/service/ReservationService.go
+++ b/service/ReservationService.go
@@ -1,0 +1,24 @@
+package service
+
+import (
+	"context"
+
+	"example.com/dto"
+	"example.com/repository"
+	"github.com/jackc/pgx/v5/pgxpool"
+)
+
+type ReservationService interface {
+	ReserveOrUpdate(ctx context.Context, reservation dto.ReservationDTO) (*dto.ReservationDTO, error)
+	GetByReservationReference(ctx context.Context, reservationReference string) (*dto.ReservationDTO, error)
+	GetByExternalReservationReference(ctx context.Context, resellerID string, externalReservationReference string) (*dto.ReservationDTO, error)
+	CancelReservation(ctx context.Context, reservationReference string, externalReservationReference string ) error
+}
+
+func NewReservationService(repo repository.ReservationRepository, repoAvailability repository.AvailabilityRepository, connPool *pgxpool.Pool) ReservationService {
+	return &ReservationServiceImpl{
+		repo: repo,
+		availability: repoAvailability,
+		dbPool: connPool,
+	}
+}

--- a/service/ReservationServiceImpl.go
+++ b/service/ReservationServiceImpl.go
@@ -1,0 +1,165 @@
+package service
+
+import (
+	"context"
+	"database/sql"
+	"errors"
+	"fmt"
+	"time"
+
+	"example.com/db"
+	"example.com/dto"
+	"example.com/repository"
+	"github.com/google/uuid"
+	"github.com/jackc/pgx/v5"
+	"github.com/jackc/pgx/v5/pgconn"
+	"github.com/jackc/pgx/v5/pgxpool"
+)
+
+type ReservationServiceImpl struct {
+	repo         repository.ReservationRepository
+	availability repository.AvailabilityRepository
+	dbPool       *pgxpool.Pool
+}
+
+
+// CancelReservation implements ReservationService.
+func (s *ReservationServiceImpl) CancelReservation(ctx context.Context, reservationReference string, externalReservationReference string) error {
+	tx, err := s.dbPool.BeginTx(ctx, pgx.TxOptions{IsoLevel: pgx.Serializable})
+	if err != nil {
+		return fmt.Errorf("failed to begin transaction: %w", err)
+	}
+	defer tx.Rollback(ctx)
+
+	qtx := db.New(tx)
+	txRepo := repository.NewDbReservationRepository(qtx, s.dbPool)
+
+	//caut rezervarea dupa reference
+	existing, err := txRepo.GetByReservationReference(ctx, reservationReference)
+	if err != nil {
+		return errors.New("INVALID_RESERVATION")
+	}
+
+	// Verific daca externalReservationReference corespunde
+	if existing.ExternalReservationReference != externalReservationReference {
+		return errors.New("INVALID_RESERVATION")
+	}
+
+	//  Dacă deja e CANCELlED
+	if existing.Status == "CANCELED" {
+		return errors.New("RESERVATION_ALREADY_CANCELED")
+	}
+
+	// Fac cancelul
+	err = txRepo.CancelReservation(ctx, reservationReference)
+	if err != nil {
+		return fmt.Errorf("failed to cancel reservation: %w", err)
+	}
+
+	//Commit
+	if err := tx.Commit(ctx); err != nil {
+		return fmt.Errorf("commit error: %w", err)
+	}
+
+	return nil
+}
+
+// GetByExternalReservationReference implements ReservationService.
+func (r *ReservationServiceImpl) GetByExternalReservationReference(ctx context.Context, resellerID string, externalReservationReference string) (*dto.ReservationDTO, error) {
+	reservation, err := r.repo.GetByExternalReservationReference(ctx, resellerID, externalReservationReference)
+	if err != nil {
+		return nil,err
+	}
+	return dto.ReservationToDTO(reservation), nil
+
+}
+
+// GetByReservationReference implements ReservationService.
+func (r *ReservationServiceImpl) GetByReservationReference(ctx context.Context, reservationReference string) (*dto.ReservationDTO, error) {
+	reservation,err:= r.repo.GetByReservationReference(ctx, reservationReference)
+	if err != nil {
+		return nil,err}
+
+	return dto.ReservationToDTO(reservation), nil
+}
+
+// ReserveOrUpdate implements ReservationService.
+func (s *ReservationServiceImpl) ReserveOrUpdate(ctx context.Context, reservation dto.ReservationDTO) (*dto.ReservationDTO, error) {
+	
+	// conversie DTO -> model
+	modelReservation, err := reservation.ToModel()
+	if err != nil {
+		return nil, err
+	}
+
+	const maxAttempts = 10
+
+	for attempt := 1; attempt <= maxAttempts; attempt++ {
+		tx, err := s.dbPool.BeginTx(ctx, pgx.TxOptions{
+			IsoLevel: pgx.Serializable,
+		})
+		if err != nil {
+			return nil, fmt.Errorf("failed to begin transaction: %w", err)
+		}
+
+		qtx := db.New(tx)
+		txRepo := repository.NewDbReservationRepository(qtx, s.dbPool)
+		txAvailabilityRepo := repository.NewDBAvailabilityRepository(s.dbPool, qtx)
+
+		// verificam daca exista deja rezervare cu externalReservationReference
+		existing, err := txRepo.GetByExternalReservationReference(ctx, modelReservation.ResellerID.String(), modelReservation.ExternalReservationReference)
+		if err != nil && !errors.Is(err, sql.ErrNoRows) {
+			tx.Rollback(ctx)
+			return nil, fmt.Errorf("db error: %w", err)
+		}
+
+		if existing != nil {
+			// verificam daca e aceeasi rezervare
+			if existing.DateTime.Equal(modelReservation.DateTime) &&
+				existing.Quantity == modelReservation.Quantity &&
+				existing.AvailabilityID == modelReservation.AvailabilityID {
+				if err := tx.Commit(ctx); err != nil {
+					return nil, fmt.Errorf("commit error: %w", err)
+				}
+				return dto.ReservationToDTO(existing), nil
+			}
+
+			// daca e diferita, o anulam
+			if err := txRepo.CancelReservation(ctx, existing.ReservationReference); err != nil {
+				tx.Rollback(ctx)
+				return nil, fmt.Errorf("failed to cancel old reservation: %w", err)
+			}
+		}
+
+		// verificam locurile disponibile
+		availableSpots, err := txAvailabilityRepo.GetAvailableVacancies(ctx, modelReservation.AvailabilityID)
+		if err != nil {
+			tx.Rollback(ctx)
+			return nil, fmt.Errorf("failed to check availability: %w", err)
+		}
+		if availableSpots < modelReservation.Quantity {
+			tx.Rollback(ctx)
+			return nil, fmt.Errorf("NO_AVAILABILITY: requested %d but only %d left", modelReservation.Quantity, availableSpots)
+		}
+
+		// cream o noua rezervare
+		modelReservation.ReservationReference = uuid.New().String()
+		newReservation, err := txRepo.ReserveOrUpdate(ctx, modelReservation)
+		if err != nil {
+			tx.Rollback(ctx)
+			return nil, fmt.Errorf("failed to create reservation: %w", err)
+		}
+
+		if err := tx.Commit(ctx); err != nil {
+			if pgxErr, ok := err.(*pgconn.PgError); ok && pgxErr.Code == "40001" {
+				time.Sleep(50 * time.Millisecond)
+				continue
+			}
+			return nil, fmt.Errorf("commit error: %w", err)
+		}
+
+		return dto.ReservationToDTO(newReservation), nil
+	}
+
+	return nil, errors.New("too many retries due to concurrent modifications")
+}

--- a/service/availabilityservice.go
+++ b/service/availabilityservice.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"time"
 
 	"example.com/db"
 	"example.com/model"
@@ -139,6 +140,19 @@ func (s *AvailabilityService) GetAvailabilitiesInRange(
 	}
 
 	return s.availabilityRepo.GetAvailabilitiesInRange(ctx, from, to)
+}
+
+func (s *AvailabilityService) GetAvailabilityIDForReservation(ctx context.Context, dateTime time.Time) (uuid.UUID, error) {
+	// apelăm repository simplu
+	// Trunchiem ora
+	dateUTC := dateTime.UTC().Truncate(24 * time.Hour)
+
+	// scoatem ora tot în UTC
+	hourUTC := dateTime.UTC()
+	hour := time.Date(1970, 1, 1, hourUTC.Hour(), hourUTC.Minute(), hourUTC.Second(), 0, time.UTC)
+
+	//fmt.Println("Getting availability ID for reservation at date:", dateUTC, "and hour:", hour)
+	return s.availabilityRepo.GetAvailabilityIdForReservation(ctx, s.queries, dateUTC, hour)
 }
 
 


### PR DESCRIPTION
 reusing existing reservations if the external reference + data match
Reservation update — canceling old reservation if data changes, creating a new one
Availability check — making sure we don’t overbook based on max_participants - sum of confirmed reservations
Precedence support — when multiple availabilities match (by date & hour), pick the one with highest precedence
Transactional logic — everything wrapped in serializable transactions with retries on serialization failures (up to 10 times)
Cancel flow — validates both reservationReference & externalReservationReference, handles already cancelled reservations
api - reserve, cancel-reservation, view reservation
 error handling according (NO_AVAILABILITY, INVALID_RESERVATION, RESERVATION_ALREADY_CANCELED, etc.)
Concurrent testing — successfully tested race conditions using parallel load